### PR TITLE
Public interface for selecting items + small refactor + #selector

### DIFF
--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import BTNavigationDropdownMenu
 
 class ViewController: UIViewController {
 
@@ -22,7 +21,7 @@ class ViewController: UIViewController {
         self.navigationController?.navigationBar.barTintColor = UIColor(red: 0.0/255.0, green:180/255.0, blue:220/255.0, alpha: 1.0)
         self.navigationController?.navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: UIColor.whiteColor()]
         
-        menuView = BTNavigationDropdownMenu(navigationController: self.navigationController, title: items.first!, items: items)
+        menuView = BTNavigationDropdownMenu(navigationController: self.navigationController, title: items.first!, items1: items)
         menuView.cellHeight = 50
         menuView.cellBackgroundColor = self.navigationController?.navigationBar.barTintColor
         menuView.cellSelectionColor = UIColor(red: 0.0/255.0, green:160.0/255.0, blue:195.0/255.0, alpha: 1.0)
@@ -33,12 +32,13 @@ class ViewController: UIViewController {
         menuView.animationDuration = 0.5
         menuView.maskBackgroundColor = UIColor.blackColor()
         menuView.maskBackgroundOpacity = 0.3
-        menuView.didSelectItemAtIndexHandler = {(indexPath: Int) -> () in
+        menuView.didSelectItemAtIndexHandler = {(indexPath: NSIndexPath) -> () in
             print("Did select item at index: \(indexPath)")
-            self.selectedCellLabel.text = items[indexPath]
+            self.selectedCellLabel.text = items[indexPath.row]
         }
         
         self.navigationItem.titleView = menuView
+        menuView.selectedItemIndex = 3
     }
 }
 

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -38,7 +38,6 @@ class ViewController: UIViewController {
         }
         
         self.navigationItem.titleView = menuView
-        menuView.selectedItemIndex = 3
     }
 }
 

--- a/Source/BTNavigationDropdownMenu.swift
+++ b/Source/BTNavigationDropdownMenu.swift
@@ -237,6 +237,12 @@ public class BTNavigationDropdownMenu: UIView {
     }
     
     public var didSelectItemAtIndexHandler: ((indexPath: NSIndexPath) -> ())?
+    public var selectedItemIndex: Int {
+        get {return tableView.selectedIndexPath.section}
+        set {
+            tableView.selectedIndexPath = NSIndexPath(forRow: 0, inSection: newValue)
+        }
+    }
     public var isShown: Bool!
 
     private var navigationController: UINavigationController?
@@ -548,6 +554,15 @@ class BTTableView: UITableView, UITableViewDelegate, UITableViewDataSource {
     // Public properties
     var configuration: BTConfiguration
     var selectRowAtIndexPathHandler: ((indexPath: NSIndexPath) -> ())?
+    var selectedIndexPath: NSIndexPath {
+        didSet {
+            if selectedIndexPath.compare(oldValue) != .OrderedSame /*&&
+                selectedIndexPath.row < self.numberOfRowsInSection(selectedIndexPath.section) &&
+                selectedIndexPath.section < self.numberOfSectionsInTableView(self)*/ {
+                reloadRowsAtIndexPaths([oldValue, selectedIndexPath], withRowAnimation: .Automatic)
+            }
+        }
+    }
     
     var items: [[String]] {
         didSet {
@@ -559,7 +574,6 @@ class BTTableView: UITableView, UITableViewDelegate, UITableViewDataSource {
     }
     
     // Private properties
-    private var selectedIndexPath: NSIndexPath
     private var sectionExpansion: [Bool]
     
     required init?(coder aDecoder: NSCoder) {
@@ -611,12 +625,27 @@ class BTTableView: UITableView, UITableViewDelegate, UITableViewDataSource {
     
     
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cell = BTTableViewCell(style: UITableViewCellStyle.Default, reuseIdentifier: "Cell", configuration: self.configuration)
-        cell.textLabel?.text = self.items[indexPath.section][indexPath.row] as? String
+
+        let identifier = "Cell"
+        var tmpCell: BTTableViewCell? = tableView.dequeueReusableCellWithIdentifier(identifier) as? BTTableViewCell
+        if (tmpCell == nil) {
+            tmpCell = BTTableViewCell(style: UITableViewCellStyle.Default, reuseIdentifier: identifier, configuration: self.configuration)
+        }
+        let cell = tmpCell!
+        cell.textLabel?.text = self.items[indexPath.section][indexPath.row]
         cell.textLabel?.textColor = selectedIndexPath == indexPath ? self.configuration.cellTextLabelSelectedColor : self.configuration.cellTextLabelColor
         cell.checkmarkIcon.hidden = self.configuration.checkMarkEnabled && (indexPath == selectedIndexPath) ? false : true
         let showExpansion = self.items[indexPath.section].count > 1 && indexPath.row == 0
         cell.expandArrowIcon.hidden = !showExpansion
+        
+        if indexPath.compare(selectedIndexPath) == .OrderedSame {
+            cell.contentView.backgroundColor = self.configuration.cellSelectionColor
+            cell.checkmarkIcon.hidden = false
+        } else {
+            cell.checkmarkIcon.hidden = true
+            cell.contentView.backgroundColor = self.configuration.cellBackgroundColor
+        }
+        
         
         if showExpansion {
             cell.expansionTapAction = { [weak self] in
@@ -641,15 +670,10 @@ class BTTableView: UITableView, UITableViewDelegate, UITableViewDataSource {
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         selectedIndexPath = indexPath
         self.selectRowAtIndexPathHandler!(indexPath: indexPath)
-        self.reloadData()
-        let cell = tableView.cellForRowAtIndexPath(indexPath) as? BTTableViewCell
-        cell?.contentView.backgroundColor = self.configuration.cellSelectionColor
     }
     
     func tableView(tableView: UITableView, didDeselectRowAtIndexPath indexPath: NSIndexPath) {
-        let cell = tableView.cellForRowAtIndexPath(indexPath) as? BTTableViewCell
-        cell?.checkmarkIcon.hidden = true
-        cell?.contentView.backgroundColor = self.configuration.cellBackgroundColor
+        selectedIndexPath = indexPath
     }
 }
 
@@ -724,7 +748,7 @@ class BTTableViewCell: UITableViewCell {
     }
     
     func rotateArrow(arrowView: UIImageView) {
-        UIView.animateWithDuration(0.2, animations: {[weak self] () -> () in
+        UIView.animateWithDuration(0.2, animations: {_ in
             arrowView.transform = CGAffineTransformRotate(arrowView.transform, 180 * CGFloat(M_PI/180))
             })
     }

--- a/Source/BTNavigationDropdownMenu.swift
+++ b/Source/BTNavigationDropdownMenu.swift
@@ -237,10 +237,10 @@ public class BTNavigationDropdownMenu: UIView {
     }
     
     public var didSelectItemAtIndexHandler: ((indexPath: NSIndexPath) -> ())?
-    public var selectedItemIndex: Int {
-        get {return tableView.selectedIndexPath.section}
+    public var selectedItemIndexPath: NSIndexPath {
+        get {return tableView.selectedIndexPath}
         set {
-            tableView.selectedIndexPath = NSIndexPath(forRow: 0, inSection: newValue)
+            tableView.selectedIndexPath = newValue
         }
     }
     public var isShown: Bool!

--- a/Source/BTNavigationDropdownMenu.swift
+++ b/Source/BTNavigationDropdownMenu.swift
@@ -302,7 +302,7 @@ public class BTNavigationDropdownMenu: UIView {
 
         // Init button as navigation title
         self.menuButton = UIButton(frame: frame)
-        self.menuButton.addTarget(self, action: "menuButtonTapped:", forControlEvents: UIControlEvents.TouchUpInside)
+        self.menuButton.addTarget(self, action: #selector(menuButtonTapped(_:)), forControlEvents: UIControlEvents.TouchUpInside)
         self.addSubview(self.menuButton)
         
         self.menuTitle = UILabel(frame: frame)
@@ -328,7 +328,7 @@ public class BTNavigationDropdownMenu: UIView {
         self.backgroundView.backgroundColor = self.configuration.maskBackgroundColor
         self.backgroundView.autoresizingMask = UIViewAutoresizing.FlexibleWidth.union(UIViewAutoresizing.FlexibleHeight)
         
-        let backgroundTapRecognizer = UITapGestureRecognizer(target: self, action: "hideMenu");
+        let backgroundTapRecognizer = UITapGestureRecognizer(target: self, action: #selector(hideMenu));
         self.backgroundView.addGestureRecognizer(backgroundTapRecognizer)
         
         // Init table view


### PR DESCRIPTION
- Added ability to select item via public interface
- Added reusing cells
- Cell selection is now configured in `cellForRowAtIndexPath`
- Adopted modern `#selector` syntax
- Fixed problems with Demo app
